### PR TITLE
refactor: rename InterwebClient to KubernetesClient

### DIFF
--- a/apps/ops-dashboard/__tests__/app/api/databases/[namespace]/[name]/backups.test.ts
+++ b/apps/ops-dashboard/__tests__/app/api/databases/[namespace]/[name]/backups.test.ts
@@ -4,7 +4,7 @@ import { GET, POST } from '@/app/api/databases/[namespace]/[name]/backups/route'
 
 // Mock the dependencies
 jest.mock('@kubernetesjs/ops', () => ({
-  InterwebClient: jest.fn().mockImplementation(() => ({
+  KubernetesClient: jest.fn().mockImplementation(() => ({
     readPostgresqlCnpgIoV1NamespacedCluster: jest.fn(),
     listPostgresqlCnpgIoV1NamespacedBackup: jest.fn(),
     get: jest.fn(),
@@ -55,9 +55,9 @@ describe('/api/databases/[namespace]/[name]/backups', () => {
           .mockResolvedValueOnce({}) // snapshot API
       };
 
-      // Mock the InterwebClient constructor
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      // Mock the KubernetesClient constructor
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/backups');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -84,8 +84,8 @@ describe('/api/databases/[namespace]/[name]/backups', () => {
           .mockResolvedValueOnce({})
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/backups');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -108,8 +108,8 @@ describe('/api/databases/[namespace]/[name]/backups', () => {
           .mockResolvedValueOnce({})
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/backups');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -135,10 +135,10 @@ describe('/api/databases/[namespace]/[name]/backups', () => {
         createBackup: jest.fn().mockResolvedValue({ name: 'backup-123' })
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
+      const { KubernetesClient } = require('@kubernetesjs/ops');
       const { PostgresDeployer } = require('@kubernetesjs/client');
       
-      InterwebClient.mockImplementation(() => mockKube);
+      KubernetesClient.mockImplementation(() => mockKube);
       PostgresDeployer.mockImplementation(() => mockPg);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/backups', {
@@ -171,8 +171,8 @@ describe('/api/databases/[namespace]/[name]/backups', () => {
         post: jest.fn().mockResolvedValue({ name: 'scheduled-backup-123' })
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/backups', {
         method: 'POST',
@@ -242,8 +242,8 @@ describe('/api/databases/[namespace]/[name]/backups', () => {
         get: jest.fn().mockResolvedValue(null) // no snapshot API
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/backups', {
         method: 'POST',
@@ -294,8 +294,8 @@ describe('/api/databases/[namespace]/[name]/backups', () => {
         readPostgresqlCnpgIoV1NamespacedCluster: jest.fn().mockRejectedValue(new Error('Unexpected error'))
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/backups', {
         method: 'POST',

--- a/apps/ops-dashboard/__tests__/app/api/databases/[namespace]/[name]/status.test.ts
+++ b/apps/ops-dashboard/__tests__/app/api/databases/[namespace]/[name]/status.test.ts
@@ -4,7 +4,7 @@ import { GET } from '@/app/api/databases/[namespace]/[name]/status/route';
 
 // Mock the dependencies
 jest.mock('@kubernetesjs/ops', () => ({
-  InterwebClient: jest.fn().mockImplementation(() => ({
+  KubernetesClient: jest.fn().mockImplementation(() => ({
     get: jest.fn(),
     readCoreV1NamespacedPod: jest.fn(),
     listCoreV1NamespacedPod: jest.fn(),
@@ -97,8 +97,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
           }) // pooler pods
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -141,8 +141,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         get: jest.fn().mockRejectedValue(new Error('status: 404'))
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -164,8 +164,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         get: jest.fn().mockRejectedValue(new Error('not found'))
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -205,8 +205,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         listCoreV1NamespacedPod: jest.fn().mockResolvedValue({ items: [] })
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -243,8 +243,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         listCoreV1NamespacedPod: jest.fn().mockResolvedValue({ items: [] })
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -281,8 +281,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         listCoreV1NamespacedPod: jest.fn().mockResolvedValue({ items: [] })
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -303,8 +303,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         get: jest.fn().mockRejectedValue(new Error('Unexpected error'))
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });
@@ -324,8 +324,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         get: jest.fn().mockRejectedValue(new Error('Unexpected error'))
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation((config) => {
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation((config) => {
         expect(config.restEndpoint).toBe('http://custom-proxy:8001');
         return mockKube;
       });
@@ -381,8 +381,8 @@ describe('/api/databases/[namespace]/[name]/status', () => {
         listCoreV1NamespacedPod: jest.fn().mockResolvedValue({ items: [] })
       };
 
-      const { InterwebClient } = require('@kubernetesjs/ops');
-      InterwebClient.mockImplementation(() => mockKube);
+      const { KubernetesClient } = require('@kubernetesjs/ops');
+      KubernetesClient.mockImplementation(() => mockKube);
 
       const request = new NextRequest('http://localhost:3000/api/databases/test-ns/test-cluster/status');
       const params = Promise.resolve({ namespace: 'test-ns', name: 'test-cluster' });

--- a/apps/ops-dashboard/__tests__/e2e/utils/workflow-helpers.ts
+++ b/apps/ops-dashboard/__tests__/e2e/utils/workflow-helpers.ts
@@ -1,9 +1,9 @@
-import { InterwebClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 import { expect,Page } from '@playwright/test';
 
 import { verifyPageLoadedSuccessfully } from './page-verification';
 
-const interweb = new InterwebClient({
+const client = new KubernetesClient({
   restEndpoint: 'http://127.0.0.1:8001',
   kubeconfig: '',
   namespace: 'default',
@@ -101,7 +101,7 @@ export async function verifyOperatorInstallation(page: Page, operatorName: strin
 }
 
 export async function verifyOperatorInstalled(operatorName: string) {
-  const crds = await interweb.listApiextensionsV1CustomResourceDefinition({query: {}});
+  const crds = await client.listApiextensionsV1CustomResourceDefinition({query: {}});
   const crdsNames = crds.items.map(crd => crd.metadata?.name ?? '');
   expect(crdsNames.some(crdName => new RegExp(operatorName).test(crdName))).toBe(true);
 }

--- a/apps/ops-dashboard/app/api/databases/[namespace]/[name]/backups/route.ts
+++ b/apps/ops-dashboard/app/api/databases/[namespace]/[name]/backups/route.ts
@@ -1,6 +1,6 @@
 import { SetupClient } from '@kubernetesjs/client';
 import { PostgresDeployer } from '@kubernetesjs/client';
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
@@ -32,7 +32,7 @@ export async function GET(
   { params }: { params: Promise<{ namespace: string; name: string }> }
 ) {
   const restEndpoint = process.env.KUBERNETES_PROXY_URL || 'http://127.0.0.1:8001';
-  const kube = new InterwebKubernetesClient({ restEndpoint } as any);
+  const kube = new KubernetesClient({ restEndpoint } as any);
   const setup = new SetupClient(kube as any);
   const pg = new PostgresDeployer(kube as any, setup as any);
   const { namespace: ns, name } = await params;
@@ -72,7 +72,7 @@ export async function POST(
   { params }: { params: Promise<{ namespace: string; name: string }> }
 ) {
   const restEndpoint = process.env.KUBERNETES_PROXY_URL || 'http://127.0.0.1:8001';
-  const kube = new InterwebKubernetesClient({ restEndpoint } as any);
+  const kube = new KubernetesClient({ restEndpoint } as any);
   const setup = new SetupClient(kube as any);
   const pg = new PostgresDeployer(kube as any, setup as any);
   const { namespace: ns, name } = await params;

--- a/apps/ops-dashboard/app/api/databases/[namespace]/[name]/status/route.ts
+++ b/apps/ops-dashboard/app/api/databases/[namespace]/[name]/status/route.ts
@@ -1,4 +1,4 @@
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
@@ -8,7 +8,7 @@ export async function GET(
   { params }: { params: Promise<{ namespace: string; name: string }> }
 ) {
   const restEndpoint = process.env.KUBERNETES_PROXY_URL || 'http://127.0.0.1:8001';
-  const kube = new InterwebKubernetesClient({ restEndpoint } as any);
+  const kube = new KubernetesClient({ restEndpoint } as any);
   const { namespace: ns, name } = await params;
 
   try {

--- a/apps/ops-dashboard/app/api/templates/[template]/route.ts
+++ b/apps/ops-dashboard/app/api/templates/[template]/route.ts
@@ -1,5 +1,5 @@
 import { Client, SetupClient } from '@kubernetesjs/client';
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 import { NextRequest, NextResponse } from 'next/server';
 
 // Initialize client with dashboard context
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     // Ensure CloudNativePG operator is installed and ready before deploying Postgres
     if (template === 'postgres') {
       const restEndpoint = process.env.KUBERNETES_PROXY_URL || 'http://127.0.0.1:8001';
-      const kube = new InterwebKubernetesClient({ restEndpoint } as any);
+      const kube = new KubernetesClient({ restEndpoint } as any);
       const setupClient = new SetupClient(kube, namespace);
 
       const connected = await setupClient.checkConnection();

--- a/apps/ops-dashboard/k8s/client.tsx
+++ b/apps/ops-dashboard/k8s/client.tsx
@@ -1,9 +1,9 @@
 import { SetupClient } from '@kubernetesjs/client';
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 
 export function createSetupClient(): SetupClient {
   const restEndpoint = process.env.KUBERNETES_PROXY_URL || 'http://127.0.0.1:8001';
   // No need to force INTERWEB_MANIFESTS_DIR here; manifests resolves from package root now.
-  const kube = new InterwebKubernetesClient({ restEndpoint } as any);
+  const kube = new KubernetesClient({ restEndpoint } as any);
   return new SetupClient(kube as any);
 }

--- a/apps/ops-dashboard/k8s/context.tsx
+++ b/apps/ops-dashboard/k8s/context.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { InterwebClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React, { createContext, useContext, useMemo, useState } from 'react';
 
@@ -12,7 +12,7 @@ export interface KubernetesConfig {
 
 // Context types
 interface KubernetesContextValue {
-  client: InterwebClient;
+  client: KubernetesClient;
   config: KubernetesConfig;
   updateConfig: (config: Partial<KubernetesConfig>) => void;
 }
@@ -54,7 +54,7 @@ export function KubernetesProvider({
 
   // Create client instance
   const client = useMemo(() => {
-    return new InterwebClient({
+    return new KubernetesClient({
       restEndpoint: config.restEndpoint,
       kubeconfig: '',
       namespace: 'default',

--- a/apps/ops-dashboard/services/kubernetes-client.ts
+++ b/apps/ops-dashboard/services/kubernetes-client.ts
@@ -1,7 +1,7 @@
-import { InterwebClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 
 // Singleton instance
-let client: InterwebClient | null = null;
+let client: KubernetesClient | null = null;
 let authHeaders: any = {};
 
 export interface K8sConfig {
@@ -10,8 +10,8 @@ export interface K8sConfig {
   namespace?: string
 }
 
-export function initializeClient(config: K8sConfig): InterwebClient {
-  client = new InterwebClient({
+export function initializeClient(config: K8sConfig): KubernetesClient {
+  client = new KubernetesClient({
     restEndpoint: config.endpoint,
     kubeconfig: '', // Add required properties
     namespace: config.namespace || 'default',
@@ -28,10 +28,10 @@ export function initializeClient(config: K8sConfig): InterwebClient {
   return client;
 }
 
-export function getClient(): InterwebClient {
+export function getClient(): KubernetesClient {
   if (!client) {
     // Default to local kubectl proxy
-    client = new InterwebClient({
+    client = new KubernetesClient({
       restEndpoint: 'http://localhost:8001',
       kubeconfig: '',
       namespace: 'default',

--- a/packages/client/__tests__/e2e/apply.ingress-nginx.test.ts
+++ b/packages/client/__tests__/e2e/apply.ingress-nginx.test.ts
@@ -1,4 +1,4 @@
-import { InterwebClient as InterwebKubernetesClient } from "@kubernetesjs/ops";
+import { KubernetesClient } from "@kubernetesjs/ops";
 import { getOperatorResources } from "@kubernetesjs/manifests";
 import { SetupClient } from "../../src/setup";
 import { ensureNamespaceReady, ensureNamespaceExists, forceDeleteNamespace } from "../utils/test-utils";
@@ -10,7 +10,7 @@ const K8S_API = process.env.K8S_API || "http://127.0.0.1:8001";
 const nsName = "ingress-nginx";
 
 describe("FULL APPLY: ingress-nginx operator", () => {
-  const api = new InterwebKubernetesClient({ restEndpoint: K8S_API } as any);
+  const api = new KubernetesClient({ restEndpoint: K8S_API } as any);
   const setup = new SetupClient(api as any);
 
   beforeAll(async () => {

--- a/packages/client/__tests__/e2e/apply.test.ts
+++ b/packages/client/__tests__/e2e/apply.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
-import { InterwebClient as InterwebKubernetesClient } from "@kubernetesjs/ops";
+import { KubernetesClient } from "@kubernetesjs/ops";
 import { SetupClient } from "../../src/setup";
 
 // Assumes a local cluster is reachable via kubectl proxy.
@@ -16,7 +16,7 @@ const NS = "interweb-apply-test";
 const CM_NAME = "apply-test-config";
 
 describe("apply: custom manifest create/replace", () => {
-  const api = new InterwebKubernetesClient({ restEndpoint: K8S_API } as any);
+  const api = new KubernetesClient({ restEndpoint: K8S_API } as any);
   const setup = new SetupClient(api as any);
 
   async function ensureNamespaceAbsent(name: string) {

--- a/packages/client/__tests__/e2e/e2e.delete.client.test.ts
+++ b/packages/client/__tests__/e2e/e2e.delete.client.test.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { InterwebClient as InterwebKubernetesClient } from "@kubernetesjs/ops";
+import { KubernetesClient } from "@kubernetesjs/ops";
 import { SetupClient } from "../../src/setup";
 import { ConfigLoader } from "../../src/config-loader";
 import type { ClusterSetupConfig } from "../../src/types";
@@ -13,7 +13,7 @@ jest.setTimeout(60_000);
 const K8S_API = process.env.K8S_API || "http://127.0.0.1:8001";
 
 describe("SetupClient deleteOperators: basic flow with config", () => {
-  const api = new InterwebKubernetesClient({ restEndpoint: K8S_API } as any);
+  const api = new KubernetesClient({ restEndpoint: K8S_API } as any);
   const setup = new SetupClient(api as any);
 
   const cfgPath = path.join(

--- a/packages/client/__tests__/e2e/e2e.postgres.test.ts
+++ b/packages/client/__tests__/e2e/e2e.postgres.test.ts
@@ -1,4 +1,4 @@
-import { InterwebClient as InterwebKubernetesClient } from "@kubernetesjs/ops";
+import { KubernetesClient } from "@kubernetesjs/ops";
 import { SetupClient } from "../../src/setup";
 import { Client } from "../../src/client";
 import { PostgresDeployer } from "../../src/deployers/postgres";
@@ -17,7 +17,7 @@ const CNPG_VERSION = "1.25.2";
 const CNPG_NAMESPACE = "cnpg-system";
 
 describe("Postgres deploy (CloudNativePG) end-to-end", () => {
-  const api = new InterwebKubernetesClient({ restEndpoint: K8S_API } as any);
+  const api = new KubernetesClient({ restEndpoint: K8S_API } as any);
   const setup = new SetupClient(api as any);
   const client = new Client({
     restEndpoint: K8S_API,

--- a/packages/client/__tests__/e2e/e2e.setup.client.test.ts
+++ b/packages/client/__tests__/e2e/e2e.setup.client.test.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { InterwebClient as InterwebKubernetesClient } from "@kubernetesjs/ops";
+import { KubernetesClient } from "@kubernetesjs/ops";
 import { SetupClient } from "../../src/setup";
 import { ConfigLoader } from "../../src/config-loader";
 import type { ClusterSetupConfig } from "../../src/types";
@@ -15,7 +15,7 @@ jest.setTimeout(15 * 60 * 1000); // 15 minutes for setup operations
 const K8S_API = process.env.K8S_API || "http://127.0.0.1:8001";
 
 describe("SetupClient: basic flow with config", () => {
-  const api = new InterwebKubernetesClient({ restEndpoint: K8S_API } as any);
+  const api = new KubernetesClient({ restEndpoint: K8S_API } as any);
   const setup = new SetupClient(api as any);
   const testCleanup = new TestCleanupRegistry();
 

--- a/packages/client/__tests__/e2e/e2e.setup.operator.test.ts
+++ b/packages/client/__tests__/e2e/e2e.setup.operator.test.ts
@@ -1,4 +1,4 @@
-import { InterwebClient as InterwebKubernetesClient } from "@kubernetesjs/ops";
+import { KubernetesClient } from "@kubernetesjs/ops";
 import { SetupClient } from "../../src/setup";
 import type { ClusterSetupConfig, OperatorConfig } from "../../src/types";
 
@@ -60,7 +60,7 @@ function resolveOperatorOrder(requested: string[]): string[] {
 }
 
 describe("SetupClient E2E (matrix): install operators", () => {
-  const api = new InterwebKubernetesClient({ restEndpoint: K8S_API } as any);
+  const api = new KubernetesClient({ restEndpoint: K8S_API } as any);
   const setup = new SetupClient(api as any);
 
   // Allow single or comma/space-separated list via OPERATOR or OPERATORS

--- a/packages/client/__tests__/utils/test-utils.ts
+++ b/packages/client/__tests__/utils/test-utils.ts
@@ -1,10 +1,10 @@
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 
 /**
  * Ensures a namespace is ready for use by waiting for any terminating namespace to be fully deleted
  */
 export async function ensureNamespaceReady(
-  api: InterwebKubernetesClient, 
+  api: KubernetesClient, 
   name: string, 
   maxWaitMs = 180000 // 3 minutes
 ): Promise<void> {
@@ -48,7 +48,7 @@ export async function ensureNamespaceReady(
  * Force delete a namespace and wait for it to be fully removed
  */
 export async function forceDeleteNamespace(
-  api: InterwebKubernetesClient, 
+  api: KubernetesClient, 
   name: string,
   maxWaitMs = 120000
 ): Promise<void> {
@@ -94,7 +94,7 @@ export async function forceDeleteNamespace(
  * Ensure namespace exists and is ready, creating it if necessary
  */
 export async function ensureNamespaceExists(
-  api: InterwebKubernetesClient,
+  api: KubernetesClient,
   name: string,
   maxWaitMs = 180000 // 3 minutes
 ): Promise<void> {
@@ -130,7 +130,7 @@ export async function ensureNamespaceExists(
 /**
  * Helper function to create a namespace
  */
-async function createNamespace(api: InterwebKubernetesClient, name: string): Promise<void> {
+async function createNamespace(api: KubernetesClient, name: string): Promise<void> {
   const namespaceManifest = {
     apiVersion: 'v1',
     kind: 'Namespace',
@@ -161,7 +161,7 @@ async function createNamespace(api: InterwebKubernetesClient, name: string): Pro
  * Clean up multiple namespaces in parallel
  */
 export async function cleanupNamespaces(
-  api: InterwebKubernetesClient,
+  api: KubernetesClient,
   namespaces: string[]
 ): Promise<void> {
   const cleanupPromises = namespaces.map(ns => 

--- a/packages/client/scripts/setup-operators.ts
+++ b/packages/client/scripts/setup-operators.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { load as loadYaml } from 'js-yaml';
 import { spawnSync } from 'child_process';
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 import { getOperatorIds } from '@kubernetesjs/manifests';
 import { SetupClient } from '../src/setup';
 import { ClusterSetupConfig, OperatorConfig } from '../src/types';
@@ -93,7 +93,7 @@ function createSetupClient(config: ClusterSetupConfig, options: OperatorScriptOp
     clientOpts.kubeconfig = options.kubeconfig;
   }
 
-  const kubeClient = new InterwebKubernetesClient(clientOpts as any);
+  const kubeClient = new KubernetesClient(clientOpts as any);
   return new SetupClient(kubeClient, defaultNamespace);
 }
 

--- a/packages/client/src/apply.ts
+++ b/packages/client/src/apply.ts
@@ -1,4 +1,4 @@
-import { InterwebClient as InterwebKubernetesClient, APIResourceList, APIResource, KubernetesResource, ObjectMeta } from '@kubernetesjs/ops';
+import { KubernetesClient, APIResourceList, APIResource, KubernetesResource, ObjectMeta } from '@kubernetesjs/ops';
 
 type GroupVersion = { group: string | null; version: string; key: string };
 
@@ -26,11 +26,11 @@ const parseApiVersion = (apiVersion: string): GroupVersion => {
 };
 
 export class K8sApplier {
-  private client: InterwebKubernetesClient;
+  private client: KubernetesClient;
   private opts: Required<ApplyOptions>;
   private discovery: Map<string, APIResourceList> = new Map();
 
-  constructor(client: InterwebKubernetesClient, opts: ApplyOptions = {}) {
+  constructor(client: KubernetesClient, opts: ApplyOptions = {}) {
     this.client = client;
     this.opts = {
       defaultNamespace: opts.defaultNamespace ?? 'default',
@@ -530,7 +530,7 @@ export class K8sApplier {
 }
 
 export async function applyKubernetesResource(
-  client: InterwebKubernetesClient,
+  client: KubernetesClient,
   manifest: KubernetesResource,
   opts: ApplyOptions = {}
 ): Promise<void> {
@@ -539,7 +539,7 @@ export async function applyKubernetesResource(
 }
 
 export async function applyKubernetesResources(
-  client: InterwebKubernetesClient,
+  client: KubernetesClient,
   manifests: KubernetesResource[],
   opts: ApplyOptions = {}
 ): Promise<void> {
@@ -548,7 +548,7 @@ export async function applyKubernetesResources(
 }
 
 export async function deleteKubernetesResource(
-  client: InterwebKubernetesClient,
+  client: KubernetesClient,
   manifest: KubernetesResource,
   opts: ApplyOptions = {}
 ): Promise<void> {
@@ -557,7 +557,7 @@ export async function deleteKubernetesResource(
 }
 
 export async function deleteKubernetesResources(
-  client: InterwebKubernetesClient,
+  client: KubernetesClient,
   manifests: KubernetesResource[],
   opts: ApplyOptions = {}
 ): Promise<void> {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { InterwebClient as InterwebKubernetesClient } from "@kubernetesjs/ops";
+import { KubernetesClient } from "@kubernetesjs/ops";
 import { ConfigLoader } from "./config-loader";
 import { SetupClient } from "./setup";
 import {
@@ -22,10 +22,10 @@ import {
   ClusterSetupConfig,
   ApplicationConfig,
   DeploymentStatus,
-  InterwebClientConfig,
+  KubernetesClientConfig,
 } from "./types";
 
-export interface InterwebContext {
+export interface KubernetesContext {
   namespace?: string;
   kubeconfig?: string;
   context?: string;
@@ -36,14 +36,14 @@ export interface InterwebContext {
 
 export class Client {
   private setupClient: SetupClient;
-  private ctx: InterwebContext;
-  private kubeClient: InterwebKubernetesClient;
+  private ctx: KubernetesContext;
+  private kubeClient: KubernetesClient;
   private pg?: PostgresDeployer;
   private templateDeployers: Map<string, BaseTemplateDeployer> = new Map();
 
-  constructor(ctx: InterwebContext = {}) {
+  constructor(ctx: KubernetesContext = {}) {
     this.ctx = ctx;
-    this.kubeClient = new InterwebKubernetesClient({
+    this.kubeClient = new KubernetesClient({
       kubeconfig: ctx.kubeconfig,
       namespace: ctx.namespace,
       context: ctx.context,

--- a/packages/client/src/deployers/minio.ts
+++ b/packages/client/src/deployers/minio.ts
@@ -1,5 +1,5 @@
 import {
-  InterwebClient as InterwebKubernetesClient,
+  KubernetesClient,
   Namespace,
   Secret,
   AppsV1Deployment,
@@ -216,11 +216,11 @@ export interface MinioDeployResult {
 }
 
 export class MinioDeployer {
-  private kube: InterwebKubernetesClient;
+  private kube: KubernetesClient;
   private setup: SetupClient;
   private log: (msg: string) => void;
 
-  constructor(kube: InterwebKubernetesClient, setup: SetupClient, log: (msg: string) => void = console.log) {
+  constructor(kube: KubernetesClient, setup: SetupClient, log: (msg: string) => void = console.log) {
     this.kube = kube;
     this.setup = setup;
     this.log = log;

--- a/packages/client/src/deployers/ollama.ts
+++ b/packages/client/src/deployers/ollama.ts
@@ -1,5 +1,5 @@
 import {
-  InterwebClient as InterwebKubernetesClient,
+  KubernetesClient,
   Namespace,
   AppsV1Deployment,
   Service,
@@ -141,11 +141,11 @@ export interface OllamaDeployResult {
 }
 
 export class OllamaDeployer {
-  private kube: InterwebKubernetesClient;
+  private kube: KubernetesClient;
   private setup: SetupClient;
   private log: (msg: string) => void;
 
-  constructor(kube: InterwebKubernetesClient, setup: SetupClient, log: (msg: string) => void = console.log) {
+  constructor(kube: KubernetesClient, setup: SetupClient, log: (msg: string) => void = console.log) {
     this.kube = kube;
     this.setup = setup;
     this.log = log;

--- a/packages/client/src/deployers/postgres.ts
+++ b/packages/client/src/deployers/postgres.ts
@@ -1,5 +1,5 @@
 import {
-  InterwebClient as InterwebKubernetesClient,
+  KubernetesClient,
   Namespace,
   Secret,
   PostgresqlCnpgIoV1Cluster,
@@ -268,11 +268,11 @@ export interface DeployResult {
 }
 
 export class PostgresDeployer {
-  private kube: InterwebKubernetesClient;
+  private kube: KubernetesClient;
   private setup: SetupClient;
   private log: (msg: string) => void;
 
-  constructor(kube: InterwebKubernetesClient, setup: SetupClient, log: (msg: string) => void = console.log) {
+  constructor(kube: KubernetesClient, setup: SetupClient, log: (msg: string) => void = console.log) {
     this.kube = kube;
     this.setup = setup;
     this.log = log;

--- a/packages/client/src/deployers/presets/base.ts
+++ b/packages/client/src/deployers/presets/base.ts
@@ -1,4 +1,4 @@
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 
 export interface TemplateDeployOptions {
   name?: string;
@@ -36,12 +36,12 @@ export interface TemplateUninstallResult {
 }
 
 export abstract class BaseTemplateDeployer {
-  protected kube: InterwebKubernetesClient;
+  protected kube: KubernetesClient;
   protected templateId: string;
   protected log: (message: string) => void;
 
   constructor(
-    kubeClient: InterwebKubernetesClient,
+    kubeClient: KubernetesClient,
     templateId: string,
     logger?: (message: string) => void
   ) {

--- a/packages/client/src/deployers/presets/minio.ts
+++ b/packages/client/src/deployers/presets/minio.ts
@@ -1,5 +1,5 @@
 import { SimpleTemplateDeployer, SimpleTemplateConfig } from './simple';
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 
 const minioConfig: SimpleTemplateConfig = {
   image: 'minio/minio:latest',
@@ -25,7 +25,7 @@ const minioConfig: SimpleTemplateConfig = {
 
 export class MinioDeployer extends SimpleTemplateDeployer {
   constructor(
-    kubeClient: InterwebKubernetesClient,
+    kubeClient: KubernetesClient,
     logger?: (message: string) => void
   ) {
     super(kubeClient, 'minio', minioConfig, logger);

--- a/packages/client/src/deployers/presets/ollama.ts
+++ b/packages/client/src/deployers/presets/ollama.ts
@@ -1,5 +1,5 @@
 import { SimpleTemplateDeployer, SimpleTemplateConfig } from './simple';
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 
 const ollamaConfig: SimpleTemplateConfig = {
   image: 'ollama/ollama:latest',
@@ -22,7 +22,7 @@ const ollamaConfig: SimpleTemplateConfig = {
 
 export class OllamaDeployer extends SimpleTemplateDeployer {
   constructor(
-    kubeClient: InterwebKubernetesClient,
+    kubeClient: KubernetesClient,
     logger?: (message: string) => void
   ) {
     super(kubeClient, 'ollama', ollamaConfig, logger);

--- a/packages/client/src/deployers/presets/postgres.ts
+++ b/packages/client/src/deployers/presets/postgres.ts
@@ -6,13 +6,13 @@ import {
   TemplateUninstallResult,
 } from './base';
 import { PostgresDeployer, PostgresDeployOptions, DeployResult, connectionInfo } from '../postgres';
-import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+import { KubernetesClient } from '@kubernetesjs/ops';
 
 /**
  * Wrapper to adapt PostgresDeployer to the template interface
  */
 export class PostgresTemplateWrapper extends BaseTemplateDeployer {
-  constructor(private postgresDeployer: PostgresDeployer, kube: InterwebKubernetesClient, log: (msg: string) => void) {
+  constructor(private postgresDeployer: PostgresDeployer, kube: KubernetesClient, log: (msg: string) => void) {
     super(kube, 'postgres', log);
   }
 

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -1,5 +1,5 @@
 import {
-  InterwebClient as InterwebKubernetesClient,
+  KubernetesClient,
   KubernetesResource,
 } from "@kubernetesjs/ops";
 import {
@@ -12,7 +12,7 @@ import {
   ClusterSetupConfig,
   ApplicationConfig,
   DeploymentStatus,
-  InterwebClientConfig,
+  KubernetesClientConfig,
   OperatorConfig,
   OperatorInfo,
   ClusterOverview,
@@ -26,11 +26,11 @@ import {
 } from "./apply";
 
 export class SetupClient {
-  private client: InterwebKubernetesClient;
+  private client: KubernetesClient;
   private defaultNamespace: string;
 
   constructor(
-    client: InterwebKubernetesClient,
+    client: KubernetesClient,
     defaultNamespace: string = "default"
   ) {
     this.client = client;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -115,7 +115,7 @@ export interface DeploymentStatus {
   }>;
 }
 
-export interface InterwebClientConfig {
+export interface KubernetesClientConfig {
   kubeconfig?: string;
   namespace?: string;
   context?: string;

--- a/packages/ops/scripts/codegen.ts
+++ b/packages/ops/scripts/codegen.ts
@@ -5,7 +5,7 @@ import schema from './swagger.json';
 
 const options = getDefaultSchemaSDKOptions({
   includePropertyComments: true,
-  clientName: 'InterwebClient',
+  clientName: 'KubernetesClient',
   includeSwaggerUrl: true,
 });
 // Apply IntOrString patch once (mutating a cloned schema)

--- a/packages/ops/src/index.ts
+++ b/packages/ops/src/index.ts
@@ -38580,7 +38580,7 @@ export interface WatchStorageV1VolumeAttachmentRequest {
 }
 export interface GetServiceAccountIssuerOpenIDKeysetRequest {}
 export interface GetCodeVersionRequest {}
-export class InterwebClient extends APIClient {
+export class KubernetesClient extends APIClient {
   constructor(options: APIClientOptions) {
     super(options);
   }


### PR DESCRIPTION
## Summary

Renames the generated client class in `@kubernetesjs/ops` from `InterwebClient` to `KubernetesClient`, aligning it with the core `kubernetesjs` package export.

```diff
// packages/ops/scripts/codegen.ts
- clientName: 'InterwebClient',
+ clientName: 'KubernetesClient',
```

Consumer imports simplified — the aliasing pattern is no longer needed:

```diff
- import { InterwebClient as InterwebKubernetesClient } from '@kubernetesjs/ops';
+ import { KubernetesClient } from '@kubernetesjs/ops';
```

Also renames related types: `InterwebClientConfig` → `KubernetesClientConfig`, `InterwebContext` → `KubernetesContext`.

30 files changed, all mechanically — no logic changes.

Link to Devin session: https://app.devin.ai/sessions/755fa6d4f98a45b5b7181c44a0a07f4d
Requested by: @pyramation