### PR TITLE
fix: use gh CLI for PR creation, bump Node to 22, add permissions

### DIFF
--- a/.github/workflows/regenerate-ops.yml
+++ b/.github/workflows/regenerate-ops.yml
@@ -29,6 +29,10 @@ on:
         default: true
 
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   regenerate:
     runs-on: ubuntu-latest
@@ -46,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -179,20 +183,25 @@ jobs:
         run: pnpm build
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'feat(ops): regenerate client with updated CRD specs'
-          title: 'feat(ops): regenerate client with updated CRD specs'
-          body: |
-            Regenerated `@kubernetesjs/ops` client from a Kind cluster with:
-            - cert-manager: ${{ inputs.cert_manager }}
-            - Prometheus Operator: ${{ inputs.prometheus }}
-            - Knative Serving: ${{ inputs.knative_serving }}
-            - Tekton Pipelines: ${{ inputs.tekton }}
-            - Traefik: ${{ inputs.traefik }}
-            - CloudNative PG: ${{ inputs.cloudnative_pg }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_SUBMODULE_PAT || github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b feat/regenerate-ops-client
+          git add packages/ops/scripts/swagger.json packages/ops/src/index.ts
+          git commit -m "feat(ops): regenerate client with updated CRD specs"
+          git push --force-with-lease origin feat/regenerate-ops-client
+          gh pr create \
+            --title "feat(ops): regenerate client with updated CRD specs" \
+            --body "Regenerated \`@kubernetesjs/ops\` client from a Kind cluster with:
+          - cert-manager: ${{ inputs.cert_manager }}
+          - Prometheus Operator: ${{ inputs.prometheus }}
+          - Knative Serving: ${{ inputs.knative_serving }}
+          - Tekton Pipelines: ${{ inputs.tekton }}
+          - Traefik: ${{ inputs.traefik }}
+          - CloudNative PG: ${{ inputs.cloudnative_pg }}
 
-            Triggered by workflow_dispatch.
-          branch: feat/regenerate-ops-client
-          delete-branch: true
+          Triggered by workflow_dispatch." \
+            --base main \
+            --head feat/regenerate-ops-client || echo "PR already exists"


### PR DESCRIPTION
## Summary

Fixes the `regenerate-ops.yml` workflow that failed on first run due to a 403 push permission error.

Changes:
- Replace `peter-evans/create-pull-request@v6` with `gh pr create` (matches the pattern used in constructive-db's `schema-sdk-update.yml`)
- Auth via `GH_TOKEN: ${{ secrets.GH_SUBMODULE_PAT || github.token }}` — uses PAT if available, falls back to built-in token
- Add top-level `permissions: contents: write, pull-requests: write` so the default token can push branches
- Bump Node from 20.x to 22.x (20 is deprecated on GitHub Actions runners)

Link to Devin session: https://app.devin.ai/sessions/409b3a5833884f2bbdfe98f3dbee192d
Requested by: @pyramation