### PR TITLE
fix: correct the Knative and Tekton manifest URLs

### DIFF
--- a/.github/workflows/regenerate-ops.yml
+++ b/.github/workflows/regenerate-ops.yml
@@ -115,14 +115,14 @@ jobs:
       - name: Install Knative Serving
         if: ${{ inputs.knative_serving }}
         run: |
-          kubectl apply -f https://github.com/knative/serving/releases/download/knative-${KNATIVE_VERSION#v}/serving-crds.yaml
-          kubectl apply -f https://github.com/knative/serving/releases/download/knative-${KNATIVE_VERSION#v}/serving-core.yaml
+          kubectl apply -f https://github.com/knative/serving/releases/download/knative-${KNATIVE_VERSION}/serving-crds.yaml
+          kubectl apply -f https://github.com/knative/serving/releases/download/knative-${KNATIVE_VERSION}/serving-core.yaml
           kubectl wait --for=condition=Available deployment/controller -n knative-serving --timeout=120s || true
 
       - name: Install Tekton Pipelines
         if: ${{ inputs.tekton }}
         run: |
-          kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml
+          kubectl apply -f https://github.com/tektoncd/pipeline/releases/download/${TEKTON_VERSION}/release.yaml
           kubectl wait --for=condition=established --timeout=60s crd/pipelines.tekton.dev
           kubectl wait --for=condition=established --timeout=60s crd/pipelineruns.tekton.dev
           kubectl wait --for=condition=established --timeout=60s crd/tasks.tekton.dev


### PR DESCRIPTION
Follow-up to #29, which merged with two broken URLs on `main`. Both 404, so `Regenerate Ops Client` currently fails at the first Knative step:

```
error: unable to read URL ".../knative-1.20.0/serving-crds.yaml",
server reported 404 Not Found
```

## The two bugs

**Knative** — the release tag keeps its `v`. `knative-${KNATIVE_VERSION#v}` stripped it and built `knative-1.20.0`; the tags are `knative-v1.20.0`. I had the evidence and misread it: a successful download of `knative-v1.22.1` earlier in the same session.

**Tekton** — `storage.googleapis.com/tekton-releases/pipeline/previous/` has no `v1.15.0`. The GitHub release asset does, so it now uses that. One host fewer as a side effect.

## How they were found, and why only one of them announced itself

The Knative one failed loudly. Tekton was still latent — it would have failed on the next dispatch with `tekton: true`.

Found by expanding the `env` block and resolving **every** URL the workflow builds, rather than just the one that failed:

```
16/16 → 200
```

Worth doing as a habit here. These are mechanical substitutions across five projects' release conventions, and each spells its tags differently — `knative-v1.22.1`, `v1.21.1`, `v34.4.1`. A substitution that looks uniform isn't.

## Note on #29

That PR claimed the substitutions were "mechanical" and that the first dispatch would be the test. Both true, and the test failed — which is the argument for verifying the URLs at authoring time rather than at dispatch time. This PR does that.