### PR TITLE
fix(ci): fetch the bot branch before pushing with a lease

### DIFF
--- a/.github/workflows/regenerate-ops.yml
+++ b/.github/workflows/regenerate-ops.yml
@@ -201,6 +201,16 @@ jobs:
           git add packages/manifests/operators packages/manifests/src/generated \
                   packages/ops/scripts/swagger.json packages/ops/src/index.ts
           git commit -m "feat: regenerate manifests and ops client"
+          # --force-with-lease needs a local ref for the remote branch to
+          # compare against. actions/checkout does not fetch this one, so the
+          # lease has nothing to check and git refuses with "stale info" —
+          # every run after the first fails at the last step, having already
+          # done all the work.
+          #
+          # Fetching it first makes the lease meaningful: the push still
+          # refuses if someone else moved the branch, which is the protection
+          # worth keeping on a branch a human may have pushed a fix to.
+          git fetch origin feat/regenerate-ops-client || true
           git push --force-with-lease origin feat/regenerate-ops-client
           gh pr create \
             --title "feat(ops): regenerate client with updated CRD specs" \


### PR DESCRIPTION
The regenerate run did everything right and failed on the last line:

```
! [rejected] feat/regenerate-ops-client -> feat/regenerate-ops-client (stale info)
```

`--force-with-lease` compares against a **local** ref for the remote branch, and `actions/checkout` doesn't fetch that branch. With nothing to compare against, git refuses rather than assuming — so the **first** run succeeds (no remote branch exists yet) and **every run after it fails**, having already spent ten minutes doing the work.

Fetching the branch first makes the lease meaningful rather than removing it. The push still refuses if someone else moved that branch, which is worth keeping since a human may have pushed a fix onto it.

## The run itself was a success

Worth recording, since this was the workflow's first execution in its rewritten form. Every new step worked:

- `pull:all` and `codegen` — 7 operators, nginx gone, traefik and tekton present
- the ordered-parts install loop with CRD waits
- `cilium install` at runtime
- swagger fetch and client regeneration
- the commit: 142,202 insertions, 73,075 deletions across 11 files

Only the push was wrong.