### PR TITLE
fix(ops): restore the ops/client subpath and IngressRoute.ingressClassName

### DIFF
--- a/packages/ops/scripts/codegen.ts
+++ b/packages/ops/scripts/codegen.ts
@@ -20,6 +20,20 @@ if (intOrString && typeof intOrString === 'object') {
   ];
 }
 
+// The vendored spec is a snapshot of one cluster's CRDs, so a field a newer
+// operator release added is missing until the spec is refetched from a cluster
+// running it. Traefik's IngressRoute gained `spec.ingressClassName` in
+// traefik/traefik#12313; keep it regardless of the snapshot's Traefik version.
+const ingressRouteSpec =
+  patchedSchema?.definitions?.['io.traefik.v1alpha1.IngressRoute']?.properties?.spec;
+if (ingressRouteSpec?.properties) {
+  ingressRouteSpec.properties.ingressClassName = {
+    description:
+      'Defines the IngressClass cluster resource to use. It replaces the deprecated kubernetes.io/ingress.class annotation.',
+    type: 'string',
+  };
+}
+
 const code = generateOpenApiClient(
   {
     ...options,

--- a/packages/ops/src/client.ts
+++ b/packages/ops/src/client.ts
@@ -1,0 +1,6 @@
+/**
+ * The transport lives once, in the core `kubernetesjs` package. This module
+ * only keeps the `@kubernetesjs/ops/client` entry point resolvable for
+ * consumers that import the client types from it.
+ */
+export * from 'kubernetesjs/client';

--- a/packages/ops/src/index.ts
+++ b/packages/ops/src/index.ts
@@ -35229,6 +35229,7 @@ export interface TraefikIoV1alpha1IngressRoute {
         namespace?: string;
       };
     };
+    ingressClassName?: string;
   };
 }
 /* io.traefik.v1alpha1.IngressRouteList */


### PR DESCRIPTION
## Summary

Two regressions in the published `@kubernetesjs/ops@1.2.1`, both found by typechecking `constructive-db` against it.

**1. `@kubernetesjs/ops/client` disappeared.** #40 deleted `packages/ops/src/client.ts` because the generated index no longer imports it — but the file was also a public entry point, so `constructive-db`'s reconciler broke with `TS2307: Cannot find module '@kubernetesjs/ops/client'`. The file comes back as a re-export only, so the transport still lives once, in `kubernetesjs`:

```ts
export * from 'kubernetesjs/client';
```

The generated index keeps importing `kubernetesjs/client` directly (unchanged codegen config); nothing routes through the shim except consumers that already imported that subpath.

**2. `IngressRoute.spec.ingressClassName` is missing from the generated types.** Traefik added it in traefik/traefik#12313, but `scripts/swagger.json` is a snapshot of one cluster's CRDs, and that cluster ran an older Traefik — so `ops@1.1.0` had the field (its snapshot came from a newer cluster) and `1.2.1` silently dropped it, breaking `spec.ingressClassName = …` in the reconciler's http-route handler. Rather than depend on which cluster the spec was last fetched from, codegen now pins the field:

```ts
patchedSchema.definitions['io.traefik.v1alpha1.IngressRoute'].properties.spec
  .properties.ingressClassName = { type: 'string', description: … };
```

Like the existing `IntOrString` patch, this is idempotent and survives a re-fetch of the spec from either an older or a newer cluster.

Regenerated output is exactly one added line (`ingressClassName?: string;` on `TraefikIoV1alpha1IngressRoute`); `pnpm build` and `pnpm lint` pass, and `dist/client.{js,d.ts}` is emitted again so the subpath resolves in the published tarball.


Link to Devin session: https://app.devin.ai/sessions/95f4ed628067485ebab80535c50d6e88
Requested by: @pyramation